### PR TITLE
Adding azpHash field support for m2m token

### DIFF
--- a/lib/middleware/jwtAuthenticator.js
+++ b/lib/middleware/jwtAuthenticator.js
@@ -8,7 +8,8 @@ function getAzpHash(azp) {
   if (!azp || azp.length === 0) {
     throw new Error('AZP not provided.')
   }
-  let azphash = 0
+  // default offset value  
+  let azphash = 100000
   for (let i = 0; i < azp.length; i++) {
     let v = azp.charCodeAt(i)
     azphash += v * (i + 1)

--- a/lib/middleware/jwtAuthenticator.js
+++ b/lib/middleware/jwtAuthenticator.js
@@ -4,6 +4,18 @@ var util = require('../util')(),
   authVerifier = require('../auth/verifier'),
   _ = require('lodash')
 
+function getAzpHash(azp) {
+  if (!azp || azp.length === 0) {
+    throw new Error('AZP not provided.')
+  }
+  let azphash = 0
+  for (let i = 0; i < azp.length; i++) {
+    let v = azp.charCodeAt(i)
+    azphash += v * (i + 1)
+  }
+  return azphash * (-1)
+}
+
 module.exports = function (options) {
   // retrieve secret from options
   let secret = _.get(options, "AUTH_SECRET") || ''
@@ -60,6 +72,7 @@ module.exports = function (options) {
                 !req.authUser.userId && 
                 !req.authUser.roles) {
               req.authUser.isMachine = true
+              req.authUser.azpHash= getAzpHash(req.authUser.azp)
             }
           }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2033,6 +2033,13 @@
         "lodash": "4.17.11",
         "reconnect-core": "1.3.0",
         "semver": "5.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
       }
     },
     "levn": {
@@ -2056,9 +2063,9 @@
       "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jsonwebtoken": "^8.3.0",
     "jwks-rsa": "^1.3.0",
     "le_node": "^1.3.1",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.15",
     "millisecond": "^0.1.2",
     "request": "^2.88.0"
   },


### PR DESCRIPTION
'azpHash' field support for m2m token. Generating unique **numeric** value from  m2m token 'azp' value through an **algo** and making **negative** for getting unique with respect to database. 
Purpose - M2M token doesn't have userid so new field 'azpHash' can be used as virtual unique userid.